### PR TITLE
Explicitly specify revision for git log

### DIFF
--- a/delete-branches/delete-branches.bash
+++ b/delete-branches/delete-branches.bash
@@ -2,6 +2,6 @@ function delete-branches() {
   git branch |
     grep --invert-match '\*' |
     cut -c 3- |
-    fzf --multi --preview="git log {}" |
+    fzf --multi --preview="git log {} --" |
     xargs --no-run-if-empty git branch --delete --force
 }

--- a/delete-branches/delete-branches.fish
+++ b/delete-branches/delete-branches.fish
@@ -2,6 +2,6 @@ function delete-branches
   git branch |
     grep --invert-match '\*' |
     cut -c 3- |
-    fzf --multi --preview="git log {}" |
+    fzf --multi --preview="git log {} --" |
     xargs --no-run-if-empty git branch --delete --force
 end


### PR DESCRIPTION
Prevents `fatal: ambiguous argument` error if the current directory
contains a file with the same name as the git branch.

PS- like your article, thanks :slightly_smiling_face: 